### PR TITLE
fix duplicate doc for Array::removeAllInstancesOf

### DIFF
--- a/modules/juce_core/containers/juce_Array.h
+++ b/modules/juce_core/containers/juce_Array.h
@@ -830,9 +830,9 @@ public:
         }
     }
 
-    /** Removes an item from the array.
+    /** Removes all occurrences of an item from the array.
 
-        This will remove the first occurrence of the given element from the array.
+        This will remove all occurrences of the given element from the array.
         If the item isn't found, no action is taken.
 
         @param valueToRemove   the object to try to remove


### PR DESCRIPTION
documentation for Array::removeAllInstancesOf() was identical to Array::removeFirstMatchingValue()